### PR TITLE
New output format: real and imaginary parts in a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ where V is a vector meson (Upsilon, JPsi, rho, phi)
 
 **Note** This code is constantly developed, and individual commits are not guaranteed to work properly. If you want to use this code in your project, it is probably good idea to first communicate directly with Heikki Mäntysaari <heikki.mantysaari@jyu.fi>
 
+**Note 2** As of Nov/2024, the output format has changed, the code now always computes the real and imaginary parts and prints both results.
+
 
 ## Compiling
  
@@ -38,52 +40,49 @@ User has to specify the dipole-target scattering amplitude. Supported dipole amp
 
  * IPsat with event-by-event fluctuating geometry
  * Wilson lines generated using the IPGlasma code (https://github.com/schenke/ipglasma)
+ * JIMWLK-evolved Wilson lines also work, the evolution can be solved using (https://github.com/hejajama/jimwlk)
 
 Examples
 
-    GSL_RNG_SEED=1 ./build/bin/subnucleondiffraction -dipole 1 ipsatproton 3.3 0.7 -real -Q2 0 -W 75 -mcintpoints 1e5
+    GSL_RNG_SEED=1 ./build/bin/subnucleondiffraction -dipole 1 ipsatproton 3.3 0.7 -Q2 0 -W 75 -mcintpoints 1e5
     
-Calculates diffractive scattering amplitude (real part, imaginary part: use `-imag` instead of `-real`)
-Q2  is the photon virtuality in GeV<sup>2</sup> and W is the center-of-mass energy (again in GeV). This woud use 10<sup>5</sup> MC integration points points are used in (adaptive) Monte Carlo integration. The MonteCarlo method (Vegas or MISER) can be selected using the `-mcint` flag (see `src/main.cpp`)
+Calculates diffractive scattering amplitude. Q2  is the photon virtuality in GeV<sup>2</sup> and W is the center-of-mass energy (again in GeV). This woud use 10<sup>5</sup> MC integration points in Monte Carlo integration. The MonteCarlo method (Vegas [default] or MISER) can be selected using the `-mcint` flag (see `src/main.cpp`)
 
 Using a heavy nucleus instead of proton, replace `1 -> 197` (Au) or any other A. For A>3 Woods-Saxon is used. Deuteron and 3He are handled separately.
 
-Random seed is set by `GSL_RNG_SEED` enviromental variable. One **must** use the same RNG_SEED when calculating real and 
-imaginary parts!
+Random seed is set by `GSL_RNG_SEED` enviromental variable. 
 
-Round proton is "ipsatproton 0 4" (first number controls the width of the Gaussian from which the hot spot locations are sampled, and the second number is the width of the hot spots. This code always uses three hotspots, edit `src/ipsat_proton.cpp` if necessary. If teh center-of-mass should be moved to the origin, add `com` at the end:
+Round IPsat-proton is e.g. `ipsatproton 0 4` (first number controls the width of the Gaussian from which the hot spot locations are sampled, and the second number is the width of the hot spot. This code always uses three hotspots, edit `src/ipsat_proton.cpp` if necessary. If the center-of-mass should be moved to the origin, add `com` at the end:
 
     -dipole 1 ipsatproton 4.5 1.0 com
 
-Q_s fluctuations for constituent quarks are set as:
+The magnitude of the Q_s fluctuations is set as
 
-    -qsfluct 0.5 -qsfluctshape quarks 
-    
-where the first number is the width of the log-normal distribution sigma.
+    -qsfluct 0.5
 
 Wilson lines generated using the IPGlasma code can be used instead of the IPsat dipole as follows: 
     
     -dipole 1 ipglasma FILENAME step
 
-The step size in fm, and should be `L/N` (`L` is the lattice length, `N` number of lattice points)
+The step size in fm, and should be `L/N` (`L` is the lattice length, `N` number of lattice points). Note: everywhere else this code uses GeV^n units.
 
-Or, it is more efficient use Wilson lines in binary format
+It is more efficient use Wilson lines in binary format (generated using the `writeInitialWilsonLines 2` option in IP-Glasma)
 
     -dipole 1 ipglasma_binary FILENAME
 
 In this case there is no need to specify the step size.
  
-The code outputs
+The code outputs the squared momentum transfer |t| and complex scattering amplitudes separately for the transverse and longitudinal photon, the syntax is
 
-    t   amplitude(T)  amplitude(L)
+    t   transverse real, transverse imag, longitudinal real, longitudinal imag
 
-So amplitudes for different polarizations separately. All dimensionful units in this code are in GeV unless stated otherwise. Note that the user has to calculate real and imaginary parts separately (but the imaginary part does not affect the coherent cross section).
+ All dimensionful units in this code are in GeV unless stated otherwise, so amplitude is in 1/GeV^2 (cross section 1/GeV^4). 
 
-The coherent cross section is then 
+The coherent diffractive cross section is 
 
     dsigma/dt = 1/(16 pi ) <A>^2   [in 1/GeV^4]
 
-Where \<A\> is the average of the amplitudes.
+Where \<A\> is the average of the amplitudes. Note that the factor $1/(16\pi)$ is not included in this code!
 
 Similalry the incoherent corss section is computed by replacing `<A>^2` by `<A^2> - <A>^2`
 
@@ -108,7 +107,7 @@ The default IPsat fit used is
  * H. Mäntysaari, P. Zurita,  Phys.Rev.D 98 (2018) 036002, arXiv:1804.05311 [hep-ph]
 
 This program also contains codes to evaluate the dipole amplitude from the
-IPsat fit 
+IPsat fit (not build by default)
 
  * A. Rezaeian, M. Siddikov, M. Van de Klundert, R. Venugopalan Phys.Rev. D87 (2013) no.3, 034002 
 

--- a/src/diffraction.hpp
+++ b/src/diffraction.hpp
@@ -18,8 +18,8 @@ public:
     Diffraction(DipoleAmplitude& dipole_, WaveFunction& wavef_);
     
     // Calculate amplitude A, this will later be averaged and squared
-    double ScatteringAmplitude(double xpom, double Qsqr, double t,Polarization pol=T );
-    double ScatteringAmplitudeIntegrand(double xpom, double Qsqr, double t, double r, double theta_r, double b, double theta_b, double z, Polarization pol=T);
+    double ScatteringAmplitude(double xpom, double Qsqr, double t,Polarization pol=T, bool real_part=true);
+    double ScatteringAmplitudeIntegrand(double xpom, double Qsqr, double t, double r, double theta_r, double b, double theta_b, double z, Polarization pol=T, bool real_part=true);
     
     // Calculate scattering amplitude in case of cylinderical cymmetry (e.g. ipsat with no constituent quarks)
     double ScatteringAmplitudeRotationalSymmetry(double xpom, double Qsqr, double t, Polarization pol=T);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -563,7 +563,7 @@ int main(int argc, char* argv[])
             cout << "# Amplitude as a function of t, Q^2=" << Qsqr << ", W=" << w << endl;
         else
             cout << "# Amplitude as a function of t, Q^2=" << Qsqr << ", xp=" << xp << endl;
-        cout << "# t  dsigma/dt [GeV^-4] columns: transverse real, transverse imag, longitudinal real, longitudinal imag" << endl;
+        cout << "# t  amplitude [GeV^-2] columns: transverse real, transverse imag, longitudinal real, longitudinal imag" << endl;
 
 
         for (t=mint; t<=maxt; t+=tstep)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,6 +92,8 @@ int main(int argc, char* argv[])
 
     bool ipglasma=false;
     bool periodic_boundary_conditions=false;
+
+    bool only_real_part=false;
     
     // nrqcd parameters
     double NRQCD_A=0.213;
@@ -109,8 +111,8 @@ int main(int argc, char* argv[])
     if (string(argv[1])=="-help")
     {
         cout << "-Q2, -W, -xp: set kinematics" << endl;
-        cout << "-real, -imag: set real/imaginary part" << endl;
         cout << "-dipole A [ipglasma,ipglasma_binary,ipsatproton,smoothnuke] [ipglasmafile ipglasmastep (fm), ipsat_proton_width ipsat_proton_quark_width] [fluxtube tunbe_normalization] [com]    com: move origin to Center of Mass (with constituent quark ipsat)" << endl;
+        cout << "-only_real_part: do not compute the imaginary part (replaced by 0)" << endl;
         cout << "-corrections: calculate correction R_g^2(1+\beta^2) as a function of t. Requires rot. sym. dipole amplitude." << endl;
         cout << "-mcintpoints points/auto" << endl;
         cout << "-skewedness: enable skewedness in dipole amplitude" << endl;
@@ -152,10 +154,8 @@ int main(int argc, char* argv[])
             w=StrToReal(argv[i+1]);
         else if (string(argv[i])=="-xp")
             xp=StrToReal(argv[i+1]);
-        else if (string(argv[i])=="-real")
-            REAL_PART = true;
-        else if (string(argv[i])=="-imag")
-            REAL_PART = false;
+        else if (string(argv[i])=="-only_real_part")
+            only_real_part=true;
         else if (string(argv[i])=="-wavef")
         {
             if (string(argv[i+1])=="gauslc")
@@ -466,6 +466,8 @@ int main(int argc, char* argv[])
     Diffraction diff(*amp, *wavef);
     diff.SetMaxR(maxr*5.068);
 
+    diff.ShowVegasIterations(false);
+
     
     cout << "# " << InfoStr() << endl;
     //cout << "# " << *wavef << endl;
@@ -554,11 +556,14 @@ int main(int argc, char* argv[])
     
     else if (mode == AMPLITUDE_DT)
     {
+
+        if (only_real_part)
+            cout <<"# Note: imaginary part set to 0" << endl;
         if (xp < 0)
             cout << "# Amplitude as a function of t, Q^2=" << Qsqr << ", W=" << w << endl;
         else
             cout << "# Amplitude as a function of t, Q^2=" << Qsqr << ", xp=" << xp << endl;
-        cout << "# t  dsigma/dt [GeV^-4] Transverse Longitudinal" << endl;
+        cout << "# t  dsigma/dt [GeV^-4] columns: transverse real, transverse imag, longitudinal real, longitudinal imag" << endl;
 
 
         for (t=mint; t<=maxt; t+=tstep)
@@ -578,14 +583,21 @@ int main(int argc, char* argv[])
                 MCINTPOINTS = MCpoints(t);
             
             cout.precision(5);
-            double trans = diff.ScatteringAmplitude(xpom, Qsqr, t, T);
-            double lng = 0;
+            double trans_r = diff.ScatteringAmplitude(xpom, Qsqr, t, T);
+            double trans_i = 0;
+            if (!only_real_part)
+                trans_i = diff.ScatteringAmplitude(xpom, Qsqr, t, T, false); // note: last argument is real_part, false=imag part
+
+            double lng_r = 0;
             if (Qsqr > 0)
-                lng = diff.ScatteringAmplitude(xpom, Qsqr, t, L);
+                lng_r = diff.ScatteringAmplitude(xpom, Qsqr, t, L);
+            double lng_i = 0;
+            if (Qsqr > 0 and !only_real_part)
+                lng_i = diff.ScatteringAmplitude(xpom, Qsqr, t, L, false);
 
             cout << t << " ";
             cout.precision(10);
-            cout << trans  << " " << lng << endl;
+            cout << trans_r  << " " << trans_i << " " << lng_r << " " << lng_i << endl;
             
 
             // Larger t step probably useful at large t
@@ -711,10 +723,6 @@ string InfoStr()
         info << "unknown!";
     
     info << endl << amp->InfoStr();
-
-    
-    if (REAL_PART) info << "# Real part";
-    else info << "# Imaginary part";
     
     if (FACTORIZE_ZINT)
         info <<". z integral factorized";

--- a/src/subnucleon_config.cpp
+++ b/src/subnucleon_config.cpp
@@ -8,9 +8,7 @@
 #include <iostream>
 #include <sstream>
 
-int MCINTPOINTS = 1e7;
-
-bool REAL_PART = true;
+int MCINTPOINTS = 2e5;
 
 bool CORRECTIONS = false;
 

--- a/src/subnucleon_config.hpp
+++ b/src/subnucleon_config.hpp
@@ -10,7 +10,7 @@
 
 const int ZINT_INTERVALS = 20;
 const double ZINT_RELACCURACY = 0.0001;
-const double MCINTACCURACY = 0.2;
+const double MCINTACCURACY = 0.01;
 
 const double DELTA_Y = 0.1; // delta y (y=ln 1/x) used to calculate corrections
 
@@ -22,8 +22,6 @@ extern bool FACTORIZE_ZINT;   // if true, we neglect exp[(1-z)r.Delta] coupling 
     // the only z dependence is in the wave function 
 
 extern int MCINTPOINTS ;
-
-extern bool REAL_PART;  // Calculate real part of the amplitude
 
 enum MCINTEGRAL
 {


### PR DESCRIPTION
To avoid excessive number of output files, from now on the code computes the real and imaginary part of the amplitude in one run.

The disadvantage is that if one only needs the coherent cross section, this takes 2x more time now.

In the future using an integration routine that supports complex/vector valued function might reduce the runtime significantly. Now real and imaginary parts are computed independently.